### PR TITLE
Allows bgr2rgb conversion in data-shim

### DIFF
--- a/waggle/__init__.py
+++ b/waggle/__init__.py
@@ -5,4 +5,4 @@
 #          http://www.wa8.gl
 # ANL:waggle-license
 
-__version__ = '0.37.1'
+__version__ = '0.37.2'

--- a/waggle/data.py
+++ b/waggle/data.py
@@ -59,7 +59,7 @@ class ImageHandler:
                 arr = np.frombuffer(data, np.uint8)
                 img =  cv2.imdecode(arr, cv2.IMREAD_COLOR)
                 if self.bgr2rgb:
-                    return ts, cv2.cvtcolor(img, cv2.COLOR_BGR2RGB)
+                    return ts, cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                 else:
                     return ts, img
         except socket.timeout:
@@ -77,7 +77,7 @@ def video_worker(cap, out, bgr2rgb=True):
         ok, img = cap.read()
         if ok:
             if bgr2rgb:
-                img = cv2.cvtcolor(img, cv2.COLOR_BGR2RGB)
+                img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
             # think about correct behavior for this
             # should expected the behavior be to make the latest
             out.put_nowait((time_ns(), img))

--- a/waggle/data.py
+++ b/waggle/data.py
@@ -49,6 +49,7 @@ class ImageHandler:
 
     def __init__(self, query, url, bgr2rgb=True):
         self.url = url
+        self.bgr2rgb = bgr2rgb
 
     def get(self, timeout=None):
         try:
@@ -57,7 +58,7 @@ class ImageHandler:
                 ts = time_ns()
                 arr = np.frombuffer(data, np.uint8)
                 img =  cv2.imdecode(arr, cv2.IMREAD_COLOR)
-                if bgr2rgb:
+                if self.bgr2rgb:
                     return ts, cv2.cvtcolor(img, cv2.COLOR_BGR2RGB)
                 else:
                     return ts, img
@@ -75,7 +76,8 @@ def video_worker(cap, out, bgr2rgb=True):
     while True:
         ok, img = cap.read()
         if ok:
-            img = cv2.cvtcolor(img, cv2.COLOR_BGR2RGB)
+            if bgr2rgb:
+                img = cv2.cvtcolor(img, cv2.COLOR_BGR2RGB)
             # think about correct behavior for this
             # should expected the behavior be to make the latest
             out.put_nowait((time_ns(), img))


### PR DESCRIPTION
OpenCV provides BGR images natively. Some machine learning models are trained against RGB images and it will be much better if the data-shim supports bgr2rgb conversion for such models. Since open_data_source uses data-config.json, users need to declare `bgr2rgb: false` in `args` section inside the file. By default, I propose bgr2rgb conversion is enabled. An example is below,
```
[
{
    "name": "Bottom Camera Video",
    "match": {
        "id": "image_bottom",
        "type": "camera/video",
        "orientation": "bottom",
        "resolution": "800x600"
    },
    "handler": {
        "type": "image",
        "args": {
            "url": "http://playback:8090/bottom/image.jpg",
            "bgr2rgb": false
        }
    }
}
]
```