### PR TITLE
Added support for Plugin context manager.

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -18,23 +18,26 @@ class TestPlugin(unittest.TestCase):
         plugin.stop()
 
     def test_publish(self):
-        plugin.publish('test.int', 1)
-        plugin.publish('test.float', 2.0)
-        plugin.publish('test.bytes', b'three')
-        plugin.publish('cows.total', 391, meta={
-            "camera": "bottom_left",
-        })
+        with Plugin() as plugin:
+            plugin.publish('test.int', 1)
+            plugin.publish('test.float', 2.0)
+            plugin.publish('test.bytes', b'three')
+            plugin.publish('cows.total', 391, meta={
+                "camera": "bottom_left",
+            })
     
     def test_publish_check_reserved(self):
-        with self.assertRaises(ValueError):
-            plugin.publish("upload", "path/to/data")
+        with Plugin() as plugin:
+            with self.assertRaises(ValueError):
+                plugin.publish("upload", "path/to/data")
 
     def test_get(self):
-        plugin.subscribe('raw.#')
-        with self.assertRaises(TimeoutError):
-            plugin.get(timeout=0)
-        with self.assertRaises(TimeoutError):
-            plugin.get(timeout=0.001)
+        with Plugin() as plugin:
+            plugin.subscribe('raw.#')
+            with self.assertRaises(TimeoutError):
+                plugin.get(timeout=0)
+            with self.assertRaises(TimeoutError):
+                plugin.get(timeout=0.001)
 
     def test_get_timestamp(self):
         ts = plugin.get_timestamp()

--- a/waggle/plugin.py
+++ b/waggle/plugin.py
@@ -99,14 +99,14 @@ class Plugin:
 
     def __enter__(self):
         self.init()
-        self.publish("plugin.status", "start")
+        # self.publish("plugin.status", "start")
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        if exc_type is None:
-            self.publish("plugin.status", "stop")
-        else:
-            self.publish("plugin.status", "error")
+        # if exc_type is None:
+        #     self.publish("plugin.status", "stop")
+        # else:
+        #     self.publish("plugin.status", "error")
         self.stop()
 
     def init(self):


### PR DESCRIPTION
This update will lay the foundational syntax for users to write clean and safe init / finalizer code. We will slowly migrate examples to using:

```python
from waggle.plugin import Plugin

with Plugin() as plugin:
  ...
```

This will automatically call init and finalize internally so the user doesn't have to manage this. This also allows us to transparently instrument plugin runs with trace messages like plugin.status upon init / finalize or on exceptions.