### PR TITLE
Remove version, url, and branch fields from docs

### DIFF
--- a/docs/writing-a-plugin.md
+++ b/docs/writing-a-plugin.md
@@ -122,7 +122,6 @@ Create and add a new file called `sage.yaml` with the following contents:
 ```yaml
 name: "hello-world"
 description: "My hello world plugin"
-version: "0.0.1"
 keywords: "hello, testing"
 authors: "Your Name <your.email@somewhere.org>, A Coworker <your.coworker@somewhere.org>"
 collaborators: "Helpful Collaborator <our.collaborator@otherplace.edu>"
@@ -134,11 +133,9 @@ source:
     - "linux/amd64"
     - "linux/arm64"
     - "linux/arm/v7"
-  url: "https://github.com/username/plugin-hello-world"
-  branch: "main"
 ```
 
-This file contains metadata about what your plugin is called, what it's supposed to do and where it lives. It is used by the [Edge Code Repository](https://portal.sagecontinuum.org/apps/explore) when submitting plugins.
+This file contains metadata about what your plugin is called and what it's supposed to do. It is used by the [Edge Code Repository](https://portal.sagecontinuum.org/apps/explore) when submitting plugins.
 
 ### 4. Add ECR media
 


### PR DESCRIPTION
@wgerlach is still going to support the `version`, `url` and `branch` fields.  However, the `url` and `branch` fields are specified by the user in the UI, and so we want to remove from docs to avoid confusion.  e.g., There were a couple cases where users were using a branch, but specifying a different branch in their `sage.yaml`.

The `version` field is also optional now.