### PR TITLE
Requeue failed publish

### DIFF
--- a/src/waggle/plugin/rabbitmq.py
+++ b/src/waggle/plugin/rabbitmq.py
@@ -79,6 +79,7 @@ class RabbitMQPublisher:
                     logger.exception("basic_publish to rabbitmq failed. will requeue message...")
                 # requeue message so we can again later
                 self.messages.put(item)
+                # propagate error up to trigger reconnect
                 raise
 
 

--- a/src/waggle/plugin/rabbitmq.py
+++ b/src/waggle/plugin/rabbitmq.py
@@ -78,6 +78,8 @@ class RabbitMQPublisher:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.exception("basic_publish to rabbitmq failed. will requeue message...")
                 # requeue message so we can again later
+                # NOTE(sean) this will reorder messages. if we realized we *must* preserve message
+                # order, we must to change this to avoid subtle bugs!
                 self.messages.put(item)
                 # propagate error up to trigger reconnect
                 raise


### PR DESCRIPTION
We saw a case with the video sampler where a publish is done infrequently enough that the RMQ connection is closed.

This is a bug fix which will requeue a message which this happens so that it may be tried again later.