### PR TITLE
SAGE-1703: publish rejects bytes values

### DIFF
--- a/src/waggle/plugin/plugin.py
+++ b/src/waggle/plugin/plugin.py
@@ -148,8 +148,8 @@ class Plugin:
     # message publish. the main reason this exists is to guard against reserved names
     # like "upload" in publish but still allow upload_file to use it.
     def __publish(self, name, value, meta, timestamp, scope="all", timeout=None):
-        if not isinstance(value, (int, float, str, bytes)):
-            raise TypeError("Value must be an int, float, string or bytes.")
+        if not isinstance(value, (int, float, str)):
+            raise TypeError("Value must be an int, float or str.")
         if not isinstance(timestamp, int):
             raise TypeError(
                 "Timestamp must be an int and have units of nanoseconds since epoch. Please see the documentation for more information on setting timestamps."

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,7 +20,7 @@ class TestPlugin(unittest.TestCase):
         with Plugin() as plugin:
             plugin.publish("test.int", 1)
             plugin.publish("test.float", 2.0)
-            plugin.publish("test.bytes", b"three")
+            plugin.publish("test.str", "three")
             plugin.publish(
                 "cows.total",
                 391,
@@ -56,7 +56,8 @@ class TestPlugin(unittest.TestCase):
             plugin.publish("test", 1)
             plugin.publish("test", 1.3)
             plugin.publish("test", "some string")
-            plugin.publish("test", b"some bytes")
+            with self.assertRaises(TypeError):
+                plugin.publish("test", b"some bytes")
             with self.assertRaises(TypeError):
                 plugin.publish("test", [1, 2, 3])
             with self.assertRaises(TypeError):


### PR DESCRIPTION
This PR drops support for bytes in the publish function. We will leave the choice of serialization of binary data to the end user.