### PR TITLE
Modified OpenCV frame read to improve the timestamping on frames

### DIFF
--- a/src/waggle/data/vision.py
+++ b/src/waggle/data/vision.py
@@ -144,16 +144,22 @@ class _Capture:
             self.capture.release()
 
     def snapshot(self):
-        timestamp = get_timestamp()
-        ok, data = self.capture.read()
+        ok = self.capture.read()
         if not ok:
             raise RuntimeError("failed to take snapshot")
+        timestamp = get_timestamp()
+        ok, data = self.capture.retrieve()
+        if not ok:
+            raise RuntimeError("failed to retrieve the taken snapshot")
         return ImageSample(data=data, timestamp=timestamp, format=self.format)
 
     def stream(self):
         while True:
+            ok = self.capture.read()
+            if not ok:
+                break
             timestamp = get_timestamp()
-            ok, data = self.capture.read()
+            ok, data = self.capture.retrieve()
             if not ok:
                 break
             yield ImageSample(data=data, timestamp=timestamp, format=self.format)

--- a/src/waggle/data/vision.py
+++ b/src/waggle/data/vision.py
@@ -144,7 +144,7 @@ class _Capture:
             self.capture.release()
 
     def snapshot(self):
-        ok = self.capture.read()
+        ok = self.capture.grab()
         if not ok:
             raise RuntimeError("failed to take snapshot")
         timestamp = get_timestamp()
@@ -155,7 +155,7 @@ class _Capture:
 
     def stream(self):
         while True:
-            ok = self.capture.read()
+            ok = self.capture.grab()
             if not ok:
                 break
             timestamp = get_timestamp()


### PR DESCRIPTION
OpenCV's VideoCapture reads frames using read(). PyWaggle timestamps those frames before calling read(). There were often times that the read took longer than usual, resulting a time discrepancy between captured frame and its timestamp.

To accurately timestamp frames, PyWaggle needs to grab a frame and timestamp it first. Then, it can run the OpenCV's retrieve function to decode the grabbed frame.